### PR TITLE
new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ This role uses [Molecule] and [Testinfra] for testing. To test:
 pip install -r requirements.txt
 ```
 
-```
 Use Self-signed SSL certificate
 -------------------------------
 
+```
 Instruct every Docker daemon to trust that certificate. The way to do this depends on your OS.
 
 Linux: Copy the ca.crt file to /etc/docker/certs.d/myregistrydomain.com:5000/ca.crt on every Docker host. You do not need to restart Docker.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Role Variables
 ```yaml
 # Directory for storing pushed images on registry host.
 docker_registry_data_directory: /var/www/docker-registry
+docker_registry_auth_path: /auth/htpasswd
 
 # Port to expose to host machine, for use in reverse proxy.
 docker_registry_expose_port: 5000
@@ -23,8 +24,10 @@ docker_registry_expose_port: 5000
 Dependencies
 ------------
 
-  * Docker container support (e.g. marklee77.docker)
-  * HTTPS reverse proxy (e.g. jdauphant.nginx)
+  * Docker container support ( geerlingguy.docker)
+  * HTTPS reverse proxy (jdauphant.nginx)
+  * Self Signed SSL (jdauphant.ssl-certs)
+  * EPEL Repo (geerlingguy.repo-epel)
 
 Example Playbook
 ----------------
@@ -74,6 +77,16 @@ This role uses [Molecule] and [Testinfra] for testing. To test:
 
 ```
 pip install -r requirements.txt
+```
+
+```
+Use Self-signed SSL certificate
+-------------------------------
+
+Instruct every Docker daemon to trust that certificate. The way to do this depends on your OS.
+
+Linux: Copy the ca.crt file to /etc/docker/certs.d/myregistrydomain.com:5000/ca.crt on every Docker host. You do not need to restart Docker.
+
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Installs and configures the official [Docker registry] container.
 Requirements
 ------------
 
-You will need to configure a reverse proxy for HTTPS with basic auth.
+You will need to configure a reverse proxy (e.g. nginx) for HTTPS. The default auth is admin/Passw0rd for registry.
 
 Role Variables
 --------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,6 @@ docker_registry_data_directory: /var/www/docker-registry
 
 # Port to expose to host machine, for use in reverse proxy.
 docker_registry_expose_port: 5000
+
+# htpasswd path
+docker_registry_auth_path: /auth/htpasswd

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Configure Docker registry container for serving container images.
   company: Freedom of the Press Foundation (@freedomofpress)
   license: GPLv2
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
   platforms:
   - name: Debian
     versions:
@@ -14,4 +14,8 @@ galaxy_info:
     - cloud
     - packaging
     - system
-dependencies: []
+  dependencies:
+    - { role: geerlingguy.repo-epel }
+    - { role: geerlingguy.docker }           
+    - { role: jdauphant.ssl-certs }
+    - { role: jdauphant.nginx }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,17 +8,47 @@
     #   group: www-data
     mode: "0755"
 
+- name: Install pip
+  yum: name=python-pip state=latest
+  when: ansible_distribution_major_version|int >= 7
+
+- name: Install dependencies 
+  pip: name={{ item }}
+  with_items:
+    - docker-py
+    - bcrypt
+  when: ansible_distribution_major_version|int >= 7
+
+- name: Install library for htpasswd management
+  yum: name=python-passlib
+  when: ansible_distribution_major_version|int >= 7
+
+- name: Add httpasswd file for basic authentication
+  htpasswd:
+    path: "{{ docker_registry_auth_path }}"
+    crypt_scheme: bcrypt
+    name: admin
+    password: 'Passw0rd'    
+    # owner: root
+    # group: www-data
+    mode: 0640
+
 - name: Run docker registry container
-  docker:
+  docker_container:
     expose: "{{ docker_registry_expose_port }}"
     image: "registry:2"
     name: registry
     ports: "{{ docker_registry_expose_port }}:{{ docker_registry_expose_port }}"
     volumes:
       - "{{ docker_registry_data_directory }}:{{ docker_registry_data_directory }}"
-    pull: missing
+      - "{{ docker_registry_auth_path }}:{{ docker_registry_auth_path }}"
     restart_policy: unless-stopped
     # "reloaded" does not appear to be idempotent
     state: started
     env:
+      REGISTRY_STORAGE: filesystem
+      REGISTRY_AUTH: htpasswd
       REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY: "{{ docker_registry_data_directory }}"
+      REGISTRY_AUTH_HTPASSWD_PATH: "{{ docker_registry_auth_path }}"
+      REGISTRY_AUTH_HTPASSWD_REALM: Registry Realm
+      


### PR DESCRIPTION
docker module is deprecated in ansible version 2.4 - new module is  docker_container. Using this module and also update with self-signed SSL and basic auth using docker registry. 